### PR TITLE
#160842015 Add modal for on-boarding players

### DIFF
--- a/src/components/Buttons.jsx
+++ b/src/components/Buttons.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
-const StyledButton = styled.button`
+const Button = styled.button`
   &:disabled {
     cursor: not-allowed;
   }
@@ -21,17 +21,17 @@ const Buttons = ({
 
   return (
     <div className="col-2 text-center">
-      <StyledButton
+      <Button
         type="button"
         className={`btn btn-lg btn-${buttonClass}`}
         onClick={check ? acceptAnswer : checkAnswer}
         disabled={selectedNumbers.length === 0}
       >
         {buttonText}
-      </StyledButton>
+      </Button>
       <br />
       <br />
-      <StyledButton
+      <Button
         type="button"
         onClick={redraw}
         className="btn btn-sm btn-warning text-white"
@@ -40,7 +40,7 @@ const Buttons = ({
         <i className="fa fa-sm fa-sync">
           {` ${redraws}`}
         </i>
-      </StyledButton>
+      </Button>
     </div>
   );
 };

--- a/src/components/Game.jsx
+++ b/src/components/Game.jsx
@@ -5,6 +5,7 @@ import Buttons from './Buttons';
 import Answers from './Answers';
 import Numbers from './Numbers';
 import DoneFrame from './DoneFrame';
+import Onboarding from './Onboarding';
 
 import possibleCombinationSum from '../helpers/possibleCombinationSum';
 import range from '../helpers/range';
@@ -15,6 +16,47 @@ const Wrapper = styled.div`
   background: linear-gradient(#CEDDE8, #84A3BD) fixed;
   height: 100vh;
   font-family: 'Josefin Sans', sans-serif;
+
+  .overlay {
+    position: fixed;
+    height: 100%;
+    width: 100%;
+    background: rgba(0,0,0,0.2);
+    z-index: 2;
+  
+    .popup {
+      background: #FFF;
+      width: 35%;
+      min-width: 400px;
+      margin: 8% auto;
+      overflow: auto;
+  
+      header {
+        background: #6A96D8;
+        text-align: center;
+        color: #FFF;
+  
+        h5 {
+          padding: 0.5em 1em;
+          margin: 0;
+  
+          span {
+            float: right;
+            cursor: pointer;
+          }
+        }
+      }
+  
+      .content {
+        padding: 0.5em 1em;
+        text-align: center;
+      }
+    }
+  }
+
+  input {
+    display: none;
+  }
 `;
 const Container = styled.div`
   flex: 1;
@@ -26,18 +68,33 @@ const Container = styled.div`
 const Header = styled.header`
   background: #6A96D8;
   color: #fff;
-  height: 70px;
   box-shadow: 0 2px 20px 4px rgba(0,0,0,0.2);
 
-  h3 {
-    padding: 0.7em 4em;
+  .container {
+    display: flex;
+    flex-flow: row nowrap;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1.25em 0;
 
-    span {
-      text-decoration: underline;
+    h3 {
+      margin: 0;
+      span {
+        text-decoration: underline;
+      }
+  
+      sup, span {
+        color: #FFB2C1;
+      }
     }
 
-    sup, span {
-      color: #FFB2C1;
+    .link {
+      margin-left: 40px;
+      cursor: pointer;
+
+      &:hover {
+        text-decoration: underline;
+      }
     }
   }
 `;
@@ -54,6 +111,7 @@ class Game extends Component {
     check: null,
     redraws: 5,
     doneStatus: null,
+    displayModal: false,
   });
 
   state = Game.initialState();
@@ -149,6 +207,10 @@ class Game extends Component {
     }
   }
 
+  showModal = () => {
+    this.setState(({ displayModal }) => ({ displayModal: !displayModal }));
+  }
+
   render() {
     const {
       selectedNumbers,
@@ -156,16 +218,28 @@ class Game extends Component {
       usedNumbers,
       check,
       redraws,
-      doneStatus
+      doneStatus,
+      displayModal,
     } = this.state;
     return (
       <Wrapper>
+        {displayModal && (
+          <Onboarding
+            showModal={this.showModal}
+            displayModal={displayModal}
+          />)}
         <Header>
-          <h3>
-            <span>Play</span>
-            Nine
-            <sup>9</sup>
-          </h3>
+          <div className="container">
+            <h3>
+              <span>Play</span>
+              Nine
+              <sup>9</sup>
+            </h3>
+            <div>
+              <span onClick={this.showModal} className="link">How To Play</span>
+              <span className="link">Leaderboard</span>
+            </div>
+          </div>
         </Header>
         <Container className="container">
           <div className="row">

--- a/src/components/Numbers.jsx
+++ b/src/components/Numbers.jsx
@@ -24,7 +24,7 @@ export const Number = styled.span`
   }
 `;
 
-const Card = styled.div`
+export const Card = styled.div`
   background: #fff;
   border-radius: 5px;
   padding: 20px;

--- a/src/components/Onboarding.jsx
+++ b/src/components/Onboarding.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const Onboarding = ({ showModal }) => (
+  <div className="overlay">
+    <div className="popup">
+      <header>
+        <h5>
+          How To Play
+          <span onClick={showModal} className="fa fa-times" />
+        </h5>
+      </header>
+      <section className="content">
+        <p>
+          The aim of the game is to select all the numbers displayed
+          on the card to match the number of randomly generated stars
+          on the left.
+        </p>
+        <hr />
+        <p>
+          You can select any possible combinations of number that sums
+          to the number of stars displayed. Check if your selection is
+          correct by clicking the blue button.
+        </p>
+        <hr />
+        <p>
+          The button is marked green for correct answers and red for
+          wrong answers. You can accept a correct answer by clicking
+          the button again to start another round. Used numbers will
+          no longer be available for selection once answer is accepted
+        </p>
+        <hr />
+        <p>
+          You are provided with 5 redraws shown on the yellow button.
+          You may use this when the numbers available for selection
+          cannot combine to satisfy the number of stars displayed.
+          This will generate a set of random stars again.
+        </p>
+        <hr />
+        <p>
+          You lose the game if there are no more redraws and the
+          unused numbers cannot combine to match number of stars.
+          Note that you can unselect a number by clicking on it in
+          the answer pane.
+        </p>
+      </section>
+    </div>
+  </div>
+);
+
+Onboarding.propTypes = {
+  showModal: PropTypes.func.isRequired,
+};
+
+export default Onboarding;


### PR DESCRIPTION
#### What does this PR do?
Adds modal popup on how to play the game
#### Description of Task to be completed?
- Add an onboarding component
- Add `How To Play` link on the header navigation
- Display popup when a user clicks on the link
- Close modal when a user clicks on the close icon 
#### How should this be manually tested?
- Clone the repo and checkout to this branch 
- Run `yarn` in your terminal to install dependencies
- Run `yarn dev` to start the application
- Navigate to [http://localhost:8080](http://localhost:8080)
- Click on the `How To Play` menu in the header bar
#### What are the relevant pivotal tracker stories?
- [#160842015](https://www.pivotaltracker.com/story/show/160842015)
#### Screenshots
![image](https://user-images.githubusercontent.com/26303683/46225451-27111b80-c351-11e8-89e6-7f3fb5175f4d.png)